### PR TITLE
fix: should handle readable listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,23 @@ module.exports = (stream, throwError) => {
       return resolve();
     }
 
-    // unpipe it
-    stream.unpipe && stream.unpipe();
-    // enable resume first
-    stream.resume();
+    if (stream.listenerCount && stream.listenerCount('readable') > 0) {
+      // https://npm.taobao.org/mirrors/node/latest/docs/api/stream.html#stream_readable_resume
+      // node 10.0.0: The resume() has no effect if there is a 'readable' event listening.
+      stream.removeAllListeners('readable');
+      // unpipe it
+      stream.unpipe && stream.unpipe();
+      // enable resume first
+      stream.resume();
+      // call resume again in nextTick
+      process.nextTick(() => stream.resume());
+    } else {
+      // unpipe it
+      stream.unpipe && stream.unpipe();
+      // enable resume first
+      stream.resume();
+    }
+
 
     if (stream._readableState && stream._readableState.ended) {
       return resolve();

--- a/index.js
+++ b/index.js
@@ -6,23 +6,18 @@ module.exports = (stream, throwError) => {
       return resolve();
     }
 
+    // unpipe it
+    stream.unpipe && stream.unpipe();
+    // enable resume first
+    stream.resume();
+
     if (stream.listenerCount && stream.listenerCount('readable') > 0) {
       // https://npm.taobao.org/mirrors/node/latest/docs/api/stream.html#stream_readable_resume
       // node 10.0.0: The resume() has no effect if there is a 'readable' event listening.
       stream.removeAllListeners('readable');
-      // unpipe it
-      stream.unpipe && stream.unpipe();
-      // enable resume first
-      stream.resume();
       // call resume again in nextTick
       process.nextTick(() => stream.resume());
-    } else {
-      // unpipe it
-      stream.unpipe && stream.unpipe();
-      // enable resume first
-      stream.resume();
     }
-
 
     if (stream._readableState && stream._readableState.ended) {
       return resolve();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "index.js"
   ],
   "scripts": {
-    "test": "npm run lint && mocha test/*.test.js -r thunk-mocha",
+    "test-local": "mocha test/*.test.js -r thunk-mocha --t timeout=5000",
+    "test": "npm run lint && npm run test-local",
     "test-cov": "istanbul cover _mocha -- test/*.test.js -r thunk-mocha",
     "lint": "eslint *.js test",
     "ci": "npm run lint && npm run test-cov"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,6 +42,37 @@ describe('test/index.test.js', () => {
     }, 100);
   });
 
+  it('should work with read stream after listening readable', () => {
+    const stream = fs.createReadStream(bigtext);
+    let data;
+    stream.on('readable', () => {
+      if (!data) {
+        data = stream.read();
+        console.log('read data %d', data && data.length);
+      }
+    });
+    return sendToWormhole(stream).then(() => {
+      assert(!data);
+    });
+  });
+
+  it('should work with read stream after readable emitted', done => {
+    const stream = fs.createReadStream(bigtext);
+    let data;
+    stream.on('readable', () => {
+      if (!data) {
+        data = stream.read();
+        console.log('read data %d', data && data.length);
+      }
+    });
+    setTimeout(() => {
+      sendToWormhole(stream).then(() => {
+        assert(data);
+        done();
+      });
+    }, 500);
+  });
+
   it('should call multi times work with read stream after pipe', done => {
     let writeSize = 0;
     class PauseStream extends Writable {


### PR DESCRIPTION
remove all listeners

> The readable.resume() method has no effect if there is a 'readable' event listener.